### PR TITLE
Remove `import * as...` statement to enable SSR usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Using as a action
 | `duration`     | 		✔     | `500` 				| The duration (in milliseconds) of the scrolling animation.
 | `delay`        | 		      | `0` 					|
 | `offset`       | 		      | `0` 					| The offset that should be applied when scrolling. This option accepts a callback function
-| `easing`       | 		      | `"cubicIn"` 	| The easing to be used when animating. Combine with [svelte easing][easing]
+| `easing`       | 		      | `cubicInOut` 	| The easing function to be used when animating. Can pass any easing from [`svelte/easing`](https://svelte.dev/docs#svelte_easing) or pass custom easing function.
 | `onStart`      | 		      | `noop` 				| A callback function that should be called when scrolling has started. Receives the target element and page offset as a parameter.
 | `onDone`       | 		      | `noop` 				| A callback function that should be called when scrolling has ended. Receives the target element and page offset  as a parameter.
 | `onAborting`   | 		      | `noop` 				| A callback function that should be called when scrolling has been aborted by the user (user scrolled, clicked etc.). Receives the target element and page offset as parameters.

--- a/README.md
+++ b/README.md
@@ -38,18 +38,18 @@ Using as a action
 
 ### Global Options
 
-|     Option     | Required | Default value | Description |
-| :------------: | :------: | :-----------: | :---------: |
-| `container`    | 		✔     | `"body"`      | Scroll container 
-| `duration`     | 		✔     | `500` 				| The duration (in milliseconds) of the scrolling animation.
-| `delay`        | 		      | `0` 					|
-| `offset`       | 		      | `0` 					| The offset that should be applied when scrolling. This option accepts a callback function
-| `easing`       | 		      | `cubicInOut` 	| The easing function to be used when animating. Can pass any easing from [`svelte/easing`](https://svelte.dev/docs#svelte_easing) or pass custom easing function.
-| `onStart`      | 		      | `noop` 				| A callback function that should be called when scrolling has started. Receives the target element and page offset as a parameter.
-| `onDone`       | 		      | `noop` 				| A callback function that should be called when scrolling has ended. Receives the target element and page offset  as a parameter.
-| `onAborting`   | 		      | `noop` 				| A callback function that should be called when scrolling has been aborted by the user (user scrolled, clicked etc.). Receives the target element and page offset as parameters.
-| `scrollX`      | 		      | `false` 			| Whether or not we want scrolling on the `x` axis
-| `scrollY`      | 		      | `true` 				| Whether or not we want scrolling on the `y` axis
+|     Option     | Required | Default value 																																									| Description |
+| :------------: | :------: | :-----------: 																																									| :---------: |
+| `container`    | 		✔     | `"body"`      																																									| Scroll container 
+| `duration`     | 		✔     | `500` 																																													| The duration (in milliseconds) of the scrolling animation.
+| `delay`        | 		      | `0` 																																														|
+| `offset`       | 		      | `0` 																																														| The offset that should be applied when scrolling. This option accepts a callback function
+| `easing`       | 		      | [`cubicInOut`](https://github.com/sveltejs/svelte/blob/master/src/runtime/easing/index.ts#L67) 	| The easing function to be used when animating. Can pass any easing from [`svelte/easing`](https://svelte.dev/docs#svelte_easing) or pass custom easing function.
+| `onStart`      | 		      | `noop` 																																													| A callback function that should be called when scrolling has started. Receives the target element and page offset as a parameter.
+| `onDone`       | 		      | `noop` 																																													| A callback function that should be called when scrolling has ended. Receives the target element and page offset  as a parameter.
+| `onAborting`   | 		      | `noop` 																																													| A callback function that should be called when scrolling has been aborted by the user (user scrolled, clicked etc.). Receives the target element and page offset as parameters.
+| `scrollX`      | 		      | `false` 																																												| Whether or not we want scrolling on the `x` axis
+| `scrollY`      | 		      | `true` 																																													| Whether or not we want scrolling on the `y` axis
 
 
 Override global options:

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import * as easings from "svelte/easing";
+import { cubicInOut } from "svelte/easing";
 import { noop, loop, now } from "svelte/internal";
 import _ from "./helper";
 
@@ -7,7 +7,7 @@ const defaultOptions = {
   duration: 500,
   delay: 0,
   offset: 0,
-  easing: "cubicInOut",
+  easing: cubicInOut,
   onStart: noop,
   onDone: noop,
   onAborting: noop,
@@ -32,9 +32,6 @@ const _scrollTo = options => {
     element
   } = options;
 
-  if (typeof easing === "string") {
-    easing = easings[easing];
-  }
   if (typeof offset === "function") {
     offset = offset();
   }


### PR DESCRIPTION
Fixes #1.

Removed ability to set easing using a string name, must be passed as function now. This removes the need for the `import * as easings from "svelte/easing"` statement.

This will allow the library to be used within bundlers that don't support the `import * as` syntax.

My use case was with Sapper, as with #1.

This _should_ resolve this scenario!