### PR TITLE
bugfix: adds scroll listeners for aborting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "svelte-scrollto",
+  "version": "0.2.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "svelte": {
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.35.0.tgz",
+      "integrity": "sha512-gknlZkR2sXheu/X+B7dDImwANVvK1R0QGQLd8CNIfxxGPeXBmePnxfzb6fWwTQRsYQG7lYkZXvpXJvxvpsoB7g=="
+    }
+  }
+}

--- a/src/helper.js
+++ b/src/helper.js
@@ -18,7 +18,7 @@ export default {
   extend(...args) {
     return Object.assign(...args);
   },
-  addScrollListeners(element, events, handler, opts = { passive: false }) {
+  addListeners(element, events, handler, opts = { passive: false }) {
     if (!(events instanceof Array)) {
      events = [events]
    }
@@ -30,7 +30,7 @@ export default {
      )
    }
  },
- removeScrollListeners(element, events, handler) {
+ removeListeners(element, events, handler) {
    if (!(events instanceof Array)) {
      events = [events]
    }

--- a/src/helper.js
+++ b/src/helper.js
@@ -1,3 +1,13 @@
+let supportsPassive = false
+try {
+  let opts = Object.defineProperty({}, 'passive', {
+    get: function() {
+      supportsPassive = true
+    },
+  })
+  window.addEventListener('test', null, opts)
+} catch (e) {}
+
 export default {
   $(selector) {
     if (typeof selector === "string") {
@@ -8,6 +18,26 @@ export default {
   extend(...args) {
     return Object.assign(...args);
   },
+  addScrollListeners(element, events, handler, opts = { passive: false }) {
+    if (!(events instanceof Array)) {
+     events = [events]
+   }
+   for (let i = 0; i < events.length; i++) {
+     element.addEventListener(
+       events[i],
+       handler,
+       supportsPassive ? opts : false
+     )
+   }
+ },
+ removeScrollListeners(element, events, handler) {
+   if (!(events instanceof Array)) {
+     events = [events]
+   }
+   for (let i = 0; i < events.length; i++) {
+     element.removeEventListener(events[i], handler)
+   }
+ },
   cumulativeOffset(element) {
     let top = 0;
     let left = 0;

--- a/src/index.js
+++ b/src/index.js
@@ -76,7 +76,7 @@ const _scrollTo = options => {
       started = true;
       onStart(element, {x, y});
     }
-    _.addScrollListeners(container, abortEvents, stop, { passive: true });
+    _.addListeners(container, abortEvents, stop, { passive: true });
   }
 
   function tick(progress) {
@@ -89,8 +89,7 @@ const _scrollTo = options => {
 
   function stop() {
     scrolling = false;
-    _.removeScrollListeners(container, abortEvents, stop);
-    
+    _.removeListeners(container, abortEvents, stop);
   }
 
   loop(now => {
@@ -192,15 +191,13 @@ export const makeScrollToAction = scrollToFunc => {
         typeof current === "string" ? { element: current } : current
       );
     };
-    node.addEventListener("click", handle);
-    node.addEventListener("touchstart", handle);
+    _.addListeners(node, ["click", "touchstart"], handle);
     return {
       update(options) {
         current = options;
       },
       destroy() {
-        node.removeEventListener("click", handle);
-        node.removeEventListener("touchstart", handle);
+        _.removeListeners(node, ["click", "touchstart"], handle);
       }
     };
   };

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,15 @@ const defaultOptions = {
   scrollY: true
 };
 
+const abortEvents = [
+  'mousedown',
+  'wheel',
+  'DOMMouseScroll',
+  'mousewheel',
+  'keyup',
+  'touchmove',
+];
+
 const _scrollTo = options => {
   let {
     offset,
@@ -67,6 +76,7 @@ const _scrollTo = options => {
       started = true;
       onStart(element, {x, y});
     }
+    _.addScrollListeners(container, abortEvents, stop, { passive: true });
   }
 
   function tick(progress) {
@@ -79,6 +89,8 @@ const _scrollTo = options => {
 
   function stop() {
     scrolling = false;
+    _.removeScrollListeners(container, abortEvents, stop);
+    
   }
 
   loop(now => {
@@ -90,6 +102,7 @@ const _scrollTo = options => {
       tick(1);
       stop();
       onDone(element, {x, y});
+      return false;
     }
 
     if (!scrolling) {

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ const abortEvents = [
   'wheel',
   'DOMMouseScroll',
   'mousewheel',
-  'keyup',
+  'keydown',
   'touchmove',
 ];
 


### PR DESCRIPTION
This adds scroll listeners for aborting the animated scroll. I noticed when using this package that scrolling or clicking during animation didn't do anything and `onAborting` always ran after `onDone`, even if no scroll events fired. 

In keeping with your inspiration for this, I used the same set-up as vue-scrollto ([here](https://github.com/rigor789/vue-scrollto/blob/bd5a1d97276977e98479f9c135114e005f7c7080/src/utils.js#L19) and [here](https://github.com/rigor789/vue-scrollto/blob/bd5a1d97276977e98479f9c135114e005f7c7080/src/scrollTo.js#L5).)

Here is a REPL with these changes that shows it working now: https://svelte.dev/repl/8d1798a853ba42988fee278a9bc29b36?version=3.35.0

Let me know if anything is off and I'll change it. Thanks!

Also, thanks for creating this! It's great!